### PR TITLE
Correct Polkit Policy

### DIFF
--- a/ubuntu/18.04/install.sh
+++ b/ubuntu/18.04/install.sh
@@ -81,19 +81,13 @@ echo "hv_sock" > /etc/modules-load.d/hv_sock.conf
 fi
 
 # Configure the policy xrdp session
-cat >/etc/polkit-1/localauthority.conf.d/02-allow-colord.conf <<EOF
-polkit.addRule(function(action, subject) {
-    if ((action.id == "org.freedesktop.color-manager.create-device" ||
-         action.id == "org.freedesktop.color-manager.modify-profile" ||
-         action.id == "org.freedesktop.color-manager.delete-device" ||
-         action.id == "org.freedesktop.color-manager.create-profile" ||
-         action.id == "org.freedesktop.color-manager.modify-profile" ||
-         action.id == "org.freedesktop.color-manager.delete-profile") &&
-        subject.isInGroup("{group}"))
-    {
-        return polkit.Result.YES;
-    }
-});
+cat >/etc/polkit-1/localauthority/50-local.d/45-allow-colord.pkla <<EOF
+[Allow Colord all Users]
+Identity=unix-user:*
+Action=org.freedesktop.color-manager.create-device;org.freedesktop.color-manager.create-profile;org.freedesktop.color-manager.delete-device;org.freedesktop.color-manager.delete-profile;org.freedesktop.color-manager.modify-device;org.freedesktop.color-manager.modify-profile
+ResultAny=no
+ResultInactive=no
+ResultActive=yes
 EOF
 
 # reconfigure the service


### PR DESCRIPTION
Whereas the polkit policy in the previous script eliminated auth popups upon a remote connection, there was a "Error detected" message box that would still periodically pop up. We must change polkit configuration to use .pkla file because this is required by Polkit ver 1.05 (which ships with Bionic Beaver). 

/etc/polkit-1/localauthority.conf.d/ should be the rightful place for this override config file to go, but it appears to not get picked up when housed there.

Brought to light with thanks to Griffon @ http://c-nergy.be/blog/?p=12043