### PR TITLE
Fix vsock configuration.

### DIFF
--- a/arch/install-config.sh
+++ b/arch/install-config.sh
@@ -31,7 +31,7 @@ systemctl enable xrdp-sesman
 
 # Configure the installed XRDP ini files.
 # use vsock transport.
-sed -i_orig -e 's/use_vsock=false/use_vsock=true/g' /etc/xrdp/xrdp.ini
+sed -i_orig -e 's/port=3389/port=vsock:\/\/-1:3389/g' /etc/xrdp/xrdp.ini
 # use rdp security.
 sed -i_orig -e 's/security_layer=negotiate/security_layer=rdp/g' /etc/xrdp/xrdp.ini
 # remove encryption validation.


### PR DESCRIPTION
The xrdp connection is currently failing with new installs (with `xrdp 0.9.12` - the current version available). This is due to a change in how `xrdp` expects `vsock` to be parameterized in `xrdp.ini`.

See [issue](https://github.com/neutrinolabs/xrdp/issues/1403) raised against `xrdp`.

The parameter `use_vsock=yes`  in `/etc/xrdp/xrdp.ini` is no longer preferred (and no longer seems to work), and the use of vsock should be specified in the `port` parameter as:
`port=vsock://-1:3389`