### PR TITLE
Update AUR Package Source (xorgxrdp)

### DIFF
--- a/arch/makepkg.sh
+++ b/arch/makepkg.sh
@@ -31,8 +31,8 @@ pushd "$TMPDIR" || exit
 # XORGXRDP
 # Devel version, because release version includes a bug crashing gnome-settings-daemon
 (
-	git clone https://aur.archlinux.org/xorgxrdp-devel-git.git
-	cd xorgxrdp-devel-git || exit
+	git clone https://aur.archlinux.org/xorgxrdp.git
+	cd xorgxrdp || exit
 	makepkg -sri --noconfirm
 )
 ###############################################################################


### PR DESCRIPTION
The AUR Package `xorgxrdp-devel-git` is deprecated, use `xorgxrdp` (prefered) or `xorgxrdp-git` instead.