### PR TITLE
add Fedora linux support

### DIFF
--- a/fedora/allow-vsock.te
+++ b/fedora/allow-vsock.te
@@ -1,0 +1,11 @@
+ 
+module allow-vsock 1.0;
+ 
+require {
+        type unconfined_service_t;
+        type unlabeled_t;
+        class vsock_socket { getattr read write };
+}
+ 
+#============= unconfined_service_t ==============
+allow unconfined_service_t unlabeled_t:vsock_socket { getattr read write };

--- a/fedora/install-config.sh
+++ b/fedora/install-config.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+#
+# This script is for Fedora Linux to configure XRDP for enhanced session mode
+#
+# The configuration is adapted from the Arch script.
+#
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo 'This script must be run with root privileges' >&2
+    exit 1
+fi
+
+# Use rpm -q to check for exact package name
+if ! rpm -q xrdp 2>&1 > /dev/null ; then
+    echo 'xrdp not installed. Run dnf install xrdp first to install xrdp.' >&2
+    exit 1
+fi
+
+###############################################################################
+# Configure XRDP
+#
+systemctl enable xrdp
+systemctl enable xrdp-sesman
+
+# Configure the installed XRDP ini files.
+# use vsock transport.
+sed -i_orig -e 's/port=3389/port=vsock:\/\/-1:3389/g' /etc/xrdp/xrdp.ini
+# use rdp security.
+sed -i_orig -e 's/security_layer=negotiate/security_layer=rdp/g' /etc/xrdp/xrdp.ini
+# remove encryption validation.
+sed -i_orig -e 's/crypt_level=high/crypt_level=none/g' /etc/xrdp/xrdp.ini
+# disable bitmap compression since its local its much faster
+sed -i_orig -e 's/bitmap_compression=true/bitmap_compression=false/g' /etc/xrdp/xrdp.ini
+#
+# sed -n -e 's/max_bpp=32/max_bpp=24/g' /etc/xrdp/xrdp.ini
+
+# use the default lightdm x display
+# sed -i_orig -e 's/X11DisplayOffset=10/X11DisplayOffset=0/g' /etc/xrdp/sesman.ini
+# rename the redirected drives to 'shared-drives'
+sed -i_orig -e 's/FuseMountName=thinclient_drives/FuseMountName=shared-drives/g' /etc/xrdp/sesman.ini
+
+# Change the allowed_users
+echo "allowed_users=anybody" > /etc/X11/Xwrapper.config
+
+
+#Ensure hv_sock gets loaded
+if [ ! -e /etc/modules-load.d/hv_sock.conf ]; then
+	echo "hv_sock" > /etc/modules-load.d/hv_sock.conf
+fi
+
+# Configure the policy xrdp session
+cat > /etc/polkit-1/rules.d/02-allow-colord.rules <<EOF
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.freedesktop.color-manager.create-device" ||
+         action.id == "org.freedesktop.color-manager.modify-profile" ||
+         action.id == "org.freedesktop.color-manager.delete-device" ||
+         action.id == "org.freedesktop.color-manager.create-profile" ||
+         action.id == "org.freedesktop.color-manager.modify-profile" ||
+         action.id == "org.freedesktop.color-manager.delete-profile") &&
+        subject.isInGroup("users"))
+    {
+        return polkit.Result.YES;
+    }
+});
+EOF
+
+# Compile selinux module!
+checkmodule -M -m -o allow-vsock.mod allow-vsock.te
+semodule_package -o allow-vsock.pp -m allow-vsock.mod
+# Install the selinux module!
+semodule -i allow-vsock.pp
+
+###############################################################################
+
+echo "####### Configuration Done #######"
+echo "Next to do"
+echo "Shutdown this VM"
+echo "On your host machine in an Administrator powershell prompt, execute this command: "
+echo "             Set-VM -VMName <your_vm_name> -EnhancedSessionTransportType HvSocket"
+echo "Start this VM, and you will see Enhanced mode available!"


### PR DESCRIPTION
- Tested on a Fedora 32 Workstation Edition
- Known problem: locking screen in gnome will lead to unable to login again.
  - Solution: disable gdm by `systemctl disable gdm` will help (Gnome will diable lock screen once detected that gdm is not running). 
